### PR TITLE
Make InputInterrupt derive from Interrupt.

### DIFF
--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -23,7 +23,7 @@ module TTY
     # Raised when the user hits the interrupt key(Control-C)
     #
     # @api public
-    InputInterrupt = Class.new(StandardError)
+    InputInterrupt = Class.new(Interrupt)
 
     # Check if Windowz mode
     #


### PR DESCRIPTION
This avoids the need to explicitly mention TTY in `rescue` clauses.

Fixes https://github.com/piotrmurach/tty-prompt/issues/98
