### PR TITLE
add support for a multiline prompt on Reader#read_line; fixes tty-prompt#111

### DIFF
--- a/lib/tty/reader/line.rb
+++ b/lib/tty/reader/line.rb
@@ -236,7 +236,10 @@ module TTY
       #
       # @api public
       def prompt_size
-        self.class.sanitize(@prompt).size
+        p = self.class.sanitize(@prompt).split(/\r?\n/)
+        # return the length of each line + screen width for every line past the first
+        # which accounts for multi-line prompts
+        p.join.length + ((p.length - 1) * TTY::Screen.width )
       end
 
       # Text size


### PR DESCRIPTION
### Describe the change
Adds/fixes multiline prompt support in Reader::Line - lines past the first add TTY::Screen.width to the prompt_size.

### Why are we doing this?
Fixes piotrmurach/tty-prompt#111 & generally improves usability.

```
[3] pry(main)> TTY::Reader.new.read_line("one?\ntwo?")
one?
one?
one?
one?
one?
one?
one?
one?
two?aaaaaaa
```

vs

```
[4] pry(main)> TTY::Reader.new.read_line("one?\ntwo?")
one?
two?aaaaaaaaaaaaaaaaaaaa
```

### Benefits
The ability to use multi-line prompts without repeating text is nice.

### Drawbacks
None, as far as I can see :)

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
