### PR TITLE
Document read_keypress(nonblock: true) in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ To read a single key stroke from the user use `read_char` or `read_keypress`:
 ```ruby
 reader.read_char
 reader.read_keypress
+reader.read_keypress(nonblock: true)
 ```
 
 ### 2.2 read_line


### PR DESCRIPTION
I had to dig thru examples to find the nonblock option. Thought it might be nice to include in readme. Feel free to close this if you don't want it there.