### PR TITLE
Don't erase lines on :down if history disabled (#20).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [v0.9.0] - 2020-xx-yy
+
+### Changed
+* Pressing :down no longer erases the #read_line input if history is disabled by Charles Pence (@pencechp)
+
 ## [v0.8.0] - 2020-06-28
 
 ### Changed

--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -256,7 +256,7 @@ module TTY
         elsif console.keys[char] == :up
           line.replace(history_previous) if history_previous?
         elsif console.keys[char] == :down
-          line.replace(history_next? ? history_next : "")
+          line.replace(history_next? ? history_next : "") if track_history?
         elsif console.keys[char] == :left
           line.left
         elsif console.keys[char] == :right

--- a/spec/unit/history_disabled_spec.rb
+++ b/spec/unit/history_disabled_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Reader, "#with_history_disabled" do
+  let(:input) { StringIO.new }
+  let(:out)   { StringIO.new }
+  let(:env)   { { "TTY_TEST" => true } }
+
+  let(:reader) {
+    described_class.new(input: input, output: out, env: env,
+                        track_history: false)
+  }
+
+  it "leaves the line alone on :up" do
+    input << "abc\e[Adef\n"
+    input.rewind
+    chars = []
+    lines = []
+    reader.on(:keypress) { |event| chars << event.value; lines << event.line }
+    answer = reader.read_line
+
+    expect(chars).to eq(%W(a b c \e[A d e f \n))
+    expect(lines).to eq(%W(a ab abc abc abcd abcde abcdef abcdef\n))
+    expect(answer).to eq("abcdef\n")
+  end
+
+  it "leaves the line alone on :down" do
+    input << "abc\e[Bdef\n"
+    input.rewind
+    chars = []
+    lines = []
+    reader.on(:keypress) { |event| chars << event.value; lines << event.line }
+    answer = reader.read_line
+
+    expect(chars).to eq(%W(a b c \e[B d e f \n))
+    expect(lines).to eq(%W(a ab abc abc abcd abcde abcdef abcdef\n))
+    expect(answer).to eq("abcdef\n")
+  end
+end


### PR DESCRIPTION
### Describe the change
As discussed in #20, don't erase the line on `:down` if `track_history?` is false.

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked? (I don't know if you have a formal style, but I copied as best I could)
[X] Rebased with `master` branch?
[N/A] Documentaion updated?
