### PR TITLE
Enables XTERM escape code \eO to allow using F1-F4 on a mac

### DIFF
--- a/lib/tty/reader/console.rb
+++ b/lib/tty/reader/console.rb
@@ -10,6 +10,7 @@ module TTY
     class Console
       ESC = "\e"
       CSI = "\e["
+      XTERM = "\eO"
 
       TIMEOUT = 0.1
 
@@ -31,7 +32,7 @@ module TTY
         @input = input
         @mode  = Mode.new(input)
         @keys  = Keys.ctrl_keys.merge(Keys.keys)
-        @escape_codes = [[ESC.ord], CSI.bytes.to_a]
+        @escape_codes = [[ESC.ord], CSI.bytes.to_a, XTERM.bytes.to_a]
       end
 
       # Get a character from console with echo

--- a/spec/unit/read_keypress_spec.rb
+++ b/spec/unit/read_keypress_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe TTY::Reader, "#read_keypress" do
     expect(answer).to eq("ㄱ")
   end
 
+  TTY::Reader::Keys.keys.each do |code, name|
+    it "reads #{Shellwords.escape(code)} as a #{name} key press" do
+      reader = described_class.new(input: input, output: out, env: env)
+      input << code
+      input.rewind
+
+      answer = reader.read_keypress
+
+      expect(answer).to eq(code)
+    end
+  end
+
   context "when Ctrl+C pressed" do
     it "defaults to raising InputInterrupt" do
       reader = described_class.new(input: input, output: out, env: env)


### PR DESCRIPTION
### Describe the change

It adds the XTERM escape code `\eO`

### Why are we doing this?

The F1-F4 keys were not correctly detected on a MacOS terminal.

### Benefits

The keys are correctly detected and can be used on MacOS (and any XTERM terminal I presume).

### Drawbacks
Possible drawbacks applying this change.

### Requirements

- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?
