### PR TITLE
Overload nonblock semantics with a timeout value

### DIFF
--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -221,8 +221,9 @@ module TTY
     #   whether to echo chars back or not, defaults to false
     # @option [Boolean] raw
     #   whenther raw mode is enabled, defaults to true
-    # @option [Boolean] nonblock
+    # @option [Boolean, Numeric] nonblock
     #   whether to wait for input or not, defaults to false
+    #   if it's Numeric, then use that for the timeout
     #
     # @return [String]
     #

--- a/lib/tty/reader/console.rb
+++ b/lib/tty/reader/console.rb
@@ -40,8 +40,9 @@ module TTY
       #   whether to echo input back or not, defaults to true
       # @param [Boolean] raw
       #   whether to use raw mode or not, defaults to false
-      # @param [Boolean] nonblock
+      # @param [Boolean, Numeric] nonblock
       #   whether to wait for input or not, defaults to false
+      #   if it's Numeric, then use that for the timeout
       #
       # @return [String]
       #
@@ -50,7 +51,7 @@ module TTY
         mode.raw(raw) do
           mode.echo(echo) do
             if nonblock
-              input.wait_readable(TIMEOUT) ? input.getc : nil
+              input.wait_readable(nonblock.is_a?(Numeric) ? nonblock : TIMEOUT) ? input.getc : nil
             else
               input.getc
             end


### PR DESCRIPTION
Useful if you have an application that would like to sleep at the end
of every loop. This will let it wait for & collect the keypress until the
sleep would have expired.

For example, this loop will sleep until approximately the start of the next
second on the system clock.

```
loop do
  draw
  now = Time.now.to_f
  codes = reader.read_keypress(raw: true, nonblock: (now.ceil(0) - now))
  command.interpret(codes) if codes
end
```

### Describe the change

Overload the semantics of the `nonblock` so that it can take a `timeout` value as well as `Boolean`.

### Why are we doing this?

I'm building an application that is like `top`: It updates the terminal screen at 1 second intervals, and
needs to listen to keyboard commands. I was having trouble capturing the key presses in my event loop.
I had a `sleep` in the loop, but then I noticed that `Console#get_char# has a `TIMEOUT` constant. 

### Benefits

This adds a useful feature for writing looping applications.

### Drawbacks

Not supported in `win_console`.

This may not be the best approach for this type of application. I did a bunch of experimentation before I
got this to work to my satisfaction. 

There are no tests around the `nonblock` option, and I'm not sure how to test a timeout option without
introducing something like the `Timecop` gem to the development environment. 

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [ ] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [X] Documentation updated?
- [ ] Changelog updated?
