### PR TITLE
Fix Multiline Prompt Line Wrapping

### DIFF
--- a/lib/tty/reader/line.rb
+++ b/lib/tty/reader/line.rb
@@ -75,7 +75,7 @@ module TTY
 
         # return the length of each line + screen width for every line
         # past the first which accounts for multi-line prompts
-        lines.join.length + ((lines.length - 1) * TTY::Screen.width)
+        lines.last.length + ((lines.length - 1) * TTY::Screen.width)
       end
 
       # Check if line is in edit mode


### PR DESCRIPTION
### Describe the change
This PR addresses an issue with multiline prompts whereby longer previous lines cause the width calculation to be incorrect, leading to strange behaviour in the terminal session. It looks like this bug was introduced in [this PR](https://github.com/piotrmurach/tty-reader/pull/15).

This is the current behaviour:

https://github.com/piotrmurach/tty-reader/assets/27725639/182e74a3-6e9d-44fb-8b19-f8d2a484bf6e

With this change, the behaviour is as follows:

https://github.com/piotrmurach/tty-reader/assets/27725639/18fb9a54-ff39-43f0-8bf0-1e9992d06a26

### Why are we doing this?
This change is being made because the prompt moving up the display is not desirable behaviour.

### Benefits
One less bug! 

### Drawbacks
If any existing code was dependent on this sort of behaviour (I sure hope not!) then it will no longer work.  

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
