### PR TITLE
cheap way to give access to ^W, etc; closes #29, #25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@
 /spec/reports/
 /tmp/
 
+# gem file
+*.gem
+
 # rspec failure tracking
 .rspec_status

--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -379,7 +379,7 @@ module TTY
         previous_key_name = key_name
 
         # trigger before line is printed to allow for line changes
-        trigger_key_event(char, line: line.to_s)
+        trigger_key_event(char, line: line)
 
         if raw && echo
           output.print(line.to_s)

--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -309,7 +309,7 @@ module TTY
         key_name = console.keys[char]
 
         if exit_keys && exit_keys.include?(key_name)
-          trigger_key_event(char, line: line.to_s)
+          trigger_key_event(char, line: line)
           break
         end
 
@@ -323,7 +323,7 @@ module TTY
           direction = key_name == :shift_tab ? :previous : :next
           if completion = @completer.complete(line, initial: initial,
                                                     direction: direction)
-            trigger_completion_event(completion, line.to_s)
+            trigger_completion_event(completion, line)
           end
         elsif key_name == :escape && completion_handler &&
               (previous_key_name == :tab || previous_key_name == :shift_tab)

--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -337,7 +337,6 @@ module TTY
           line.delete
         elsif key_name.to_s =~ /ctrl_/
           # skip
-          # trigger_key_event(key_name, line: line)
         elsif key_name == :up
           @history.replace(line.text) if history_in_use
           if history_previous?

--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -337,6 +337,7 @@ module TTY
           line.delete
         elsif key_name.to_s =~ /ctrl_/
           # skip
+          # trigger_key_event(key_name, line: line)
         elsif key_name == :up
           @history.replace(line.text) if history_in_use
           if history_previous?

--- a/lib/tty/reader/line.rb
+++ b/lib/tty/reader/line.rb
@@ -335,8 +335,14 @@ module TTY
 
       # to_str enables type coercion and thus `line` in
       # `trigger_char_event` does not need to be flattened to a string.
-      alias to_str  to_s
-      alias inspect to_s
+      alias to_str to_s
+
+      # Overload inspect
+      #
+      # @api public
+      def inspect
+        to_s.inspect
+      end
 
       # Overload equality comparison
       #

--- a/lib/tty/reader/line.rb
+++ b/lib/tty/reader/line.rb
@@ -332,6 +332,10 @@ module TTY
       def to_s
         "#{@prompt}#{@text}"
       end
+
+      # to_str enables type coercion and thus `line` in
+      # `trigger_char_event` does not need to be flattened to a string.
+      alias to_str  to_s
       alias inspect to_s
 
       # Text size

--- a/lib/tty/reader/line.rb
+++ b/lib/tty/reader/line.rb
@@ -338,6 +338,18 @@ module TTY
       alias to_str  to_s
       alias inspect to_s
 
+      # Overload equality comparison
+      #
+      # @api public
+      def ==(other)
+        if other.is_a? self.class
+          super other
+        else
+          other = other.to_s if other.respond_to? :to_s
+          to_s == other
+        end
+      end
+
       # Text size
       #
       # @api public

--- a/lib/tty/reader/line.rb
+++ b/lib/tty/reader/line.rb
@@ -304,7 +304,6 @@ module TTY
       #
       # @api public
       def <<(str)
-        warn str
         @text << str
         @cursor += str.length
       end

--- a/lib/tty/reader/line.rb
+++ b/lib/tty/reader/line.rb
@@ -303,9 +303,10 @@ module TTY
       # Add char and move cursor
       #
       # @api public
-      def <<(char)
-        @text << char
-        @cursor += 1
+      def <<(str)
+        warn str
+        @text << str
+        @cursor += str.length
       end
 
       # Remove char from the line at current position

--- a/spec/unit/complete_word_spec.rb
+++ b/spec/unit/complete_word_spec.rb
@@ -302,8 +302,11 @@ RSpec.describe TTY::Reader, "complete word" do
   it "triggers completion event after completing the first suggestion" do
     @completions = %w[aa ab ac]
     completion_event = nil
+    test_line = nil # state of the line at the time the event is fired
+
     reader.on(:complete) do |event|
       completion_event = event
+      test_line = event.line.dup # we duplicate to cut the strings
       formatted_completions = event.completions.map do |compl|
         compl == event.completion ? "(#{compl})" : compl
       end
@@ -316,7 +319,7 @@ RSpec.describe TTY::Reader, "complete word" do
     expect(answer).to eq("x aa\n")
     expect(completion_event.completion).to eq("aa")
     expect(completion_event.completions).to eq(@completions)
-    expect(completion_event.line).to eq("x aa")
+    expect(test_line).to eq("x aa") # implicit test of to_s and ==
     expect(completion_event.word).to eq("a")
 
     output.rewind

--- a/spec/unit/history_disabled_spec.rb
+++ b/spec/unit/history_disabled_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe TTY::Reader, "#with_history_disabled" do
     input.rewind
     chars = []
     lines = []
-    reader.on(:keypress) { |event| chars << event.value; lines << event.line }
+    reader.on(:keypress) do |event|
+      chars << event.value
+      lines << event.line.to_s
+    end
     answer = reader.read_line
 
     expect(chars).to eq(%W(a b c \e[A d e f \n))
@@ -28,7 +31,10 @@ RSpec.describe TTY::Reader, "#with_history_disabled" do
     input.rewind
     chars = []
     lines = []
-    reader.on(:keypress) { |event| chars << event.value; lines << event.line }
+    reader.on(:keypress) do |event|
+      chars << event.value
+      lines << event.line.to_s
+    end
     answer = reader.read_line
 
     expect(chars).to eq(%W(a b c \e[B d e f \n))

--- a/spec/unit/history_disabled_spec.rb
+++ b/spec/unit/history_disabled_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TTY::Reader, "#with_history_disabled" do
     lines = []
     reader.on(:keypress) do |event|
       chars << event.value
-      lines << event.line.to_s
+      lines << event.line.dup # sever line object
     end
     answer = reader.read_line
 
@@ -33,7 +33,7 @@ RSpec.describe TTY::Reader, "#with_history_disabled" do
     lines = []
     reader.on(:keypress) do |event|
       chars << event.value
-      lines << event.line.to_s
+      lines << event.line.dup
     end
     answer = reader.read_line
 

--- a/spec/unit/publish_keypress_event_spec.rb
+++ b/spec/unit/publish_keypress_event_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe TTY::Reader, "#publish_keypress_event" do
     input.rewind
     chars = []
     lines = []
-    reader.on(:keypress) { |event| chars << event.value; lines << event.line }
+    reader.on(:keypress) do |event|
+      chars << event.value
+      lines << event.line.to_s
+    end
+
     answer = reader.read_line
 
     expect(chars).to eq(%W(a b c \n))

--- a/spec/unit/read_line_spec.rb
+++ b/spec/unit/read_line_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe TTY::Reader, "#read_line" do
 
       reader.on(:keypress) do |event|
         chars << event.value
-        lines << event.line
+        lines << event.line.to_s
       end
 
       3.times do
@@ -171,7 +171,7 @@ RSpec.describe TTY::Reader, "#read_line" do
 
       reader.on(:keypress) do |event|
         chars << event.value
-        lines << event.line
+        lines << event.line.to_s
       end
 
       reader.read_line
@@ -206,7 +206,7 @@ RSpec.describe TTY::Reader, "#read_line" do
       answer = nil
       lines = []
 
-      reader.on(:keypress) { |event| lines << event.line }
+      reader.on(:keypress) { |event| lines << event.line.to_s }
 
       4.times do
         answer = reader.read_line
@@ -250,7 +250,7 @@ RSpec.describe TTY::Reader, "#read_line" do
       answer = nil
       lines = []
 
-      reader.on(:keypress) { |event| lines << event.line }
+      reader.on(:keypress) { |event| lines << event.line.to_s }
 
       3.times do
         answer = reader.read_line
@@ -271,7 +271,7 @@ RSpec.describe TTY::Reader, "#read_line" do
       answer = nil
       lines = []
 
-      reader.on(:keypress) { |event| lines << event.line }
+      reader.on(:keypress) { |event| lines << event.line.to_s }
 
       3.times do
         answer = reader.read_line
@@ -289,7 +289,7 @@ RSpec.describe TTY::Reader, "#read_line" do
       answer = nil
       lines = []
 
-      reader.on(:keypress) { |event| lines << event.line }
+      reader.on(:keypress) { |event| lines << event.line.to_s }
 
       3.times do
         answer = reader.read_line


### PR DESCRIPTION
### Describe the change
This is a trivial change that affords `^W` etc; closing #29 and #25.

### Why are we doing this?
Users expect common shell key bindings to be available.

### Benefits
The ability to set said key bindings.

### Drawbacks
Don't know. There is a tradeoff between passing `line` into the key event rather than `line.to_s` and the downstream expectation that nothing is going to change that value. I had to change the unit tests to pass, but at a glance that seems more reasonable. I probably would have designed it so the return value of `trigger` is captured as a replacement for the line, but introducing that now would probably break more stuff downstream.