### PR TITLE
bump wisper gem version (2->3)

### DIFF
--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -158,7 +158,7 @@ module TTY
     #
     # @api public
     def subscribe(listener, options = {})
-      old_subcribe(listener, options)
+      old_subcribe(listener, **options)
       object = self
       if block_given?
         object = yield

--- a/tty-reader.gemspec
+++ b/tty-reader.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "tty-screen", "~> 0.8"
   spec.add_dependency "tty-cursor", "~> 0.7"
-  spec.add_dependency "wisper", "~> 2.0"
+  spec.add_dependency "wisper", "~> 3.0"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0"


### PR DESCRIPTION
### Describe the change
Bump wisper gem version to v3 from v2.
Tested `tty-prompt` with this new change, no issues.
Tested on Ruby versions: 2.7.8 and 3.4.0.preview2

### Why are we doing this?
My codebase depends on wisper v3 and its [kwargs](https://github.com/krisleech/wisper/blob/master/CHANGELOG.md#300rc1-6th-july-2023) API improvement 

### Drawbacks
If any of tty-* family gems rely on `tty-reader` pub/sub system, that may cause issues.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?

