### PR TITLE
Use wisper v3.0

### DIFF
--- a/lib/tty/reader.rb
+++ b/lib/tty/reader.rb
@@ -157,8 +157,8 @@ module TTY
     # @return [self|yield]
     #
     # @api public
-    def subscribe(listener, options = {})
-      old_subcribe(listener, options)
+    def subscribe(listener, **options)
+      old_subcribe(listener, **options)
       object = self
       if block_given?
         object = yield

--- a/tty-reader.gemspec
+++ b/tty-reader.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "tty-screen", "~> 0.8"
   spec.add_dependency "tty-cursor", "~> 0.7"
-  spec.add_dependency "wisper", "~> 2.0"
+  spec.add_dependency "wisper", ">= 3.0"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0"


### PR DESCRIPTION
### Describe the change

This change makes the library use version 3 of wisper. It uses ruby3.0 keywords arguments

### Why are we doing this?
This addresses issue #33.

### Benefits
more uptodate dependencies supporting newer ruby versions explicitly.

### Drawbacks
not supporting older ruby versions.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?
